### PR TITLE
Add winutil executor when provided with config.json

### DIFF
--- a/MicroWin/AppState.cs
+++ b/MicroWin/AppState.cs
@@ -22,6 +22,7 @@ namespace MicroWin
         public static DriverExportMode DriverExportMode { get; set; } = DriverExportMode.NoExport;
         public static bool UseUEFICA23Bins { get; set; } = true;
         public static string? SaveISO { get; set; }
+        public static string? WinUtilConfigPath { get; set; }
 
         public static string Version => "v2.0";
     }

--- a/MicroWin/MainForm.Designer.cs
+++ b/MicroWin/MainForm.Designer.cs
@@ -71,6 +71,10 @@
             logTB = new TextBox();
             label14 = new Label();
             label15 = new Label();
+            winutilConfigLabel = new Label();
+            winutilConfigTextBox = new TextBox();
+            winutilConfigBrowseBtn = new Button();
+            winutilConfigDialog = new OpenFileDialog();
             UserAccountsPage = new Panel();
             panel1 = new Panel();
             tableLayoutPanel3 = new TableLayoutPanel();
@@ -230,6 +234,9 @@
             IsoSettingsPage.Controls.Add(ReportToolCB);
             IsoSettingsPage.Controls.Add(label11);
             IsoSettingsPage.Controls.Add(label12);
+            IsoSettingsPage.Controls.Add(winutilConfigLabel);
+            IsoSettingsPage.Controls.Add(winutilConfigTextBox);
+            IsoSettingsPage.Controls.Add(winutilConfigBrowseBtn);
             IsoSettingsPage.Dock = DockStyle.Fill;
             IsoSettingsPage.Location = new Point(0, 0);
             IsoSettingsPage.Name = "IsoSettingsPage";
@@ -258,6 +265,38 @@
             DriverExportCombo.Size = new Size(374, 23);
             DriverExportCombo.TabIndex = 9;
             DriverExportCombo.SelectedIndexChanged += DriverExportCombo_SelectedIndexChanged;
+            // 
+            // winutilConfigLabel
+            // 
+            winutilConfigLabel.AutoSize = true;
+            winutilConfigLabel.Location = new Point(80, 265);
+            winutilConfigLabel.Name = "winutilConfigLabel";
+            winutilConfigLabel.Size = new Size(130, 15);
+            winutilConfigLabel.TabIndex = 11;
+            winutilConfigLabel.Text = "WinUtil Config (JSON):";
+            // 
+            // winutilConfigTextBox
+            // 
+            winutilConfigTextBox.Location = new Point(83, 286);
+            winutilConfigTextBox.Name = "winutilConfigTextBox";
+            winutilConfigTextBox.Size = new Size(293, 23);
+            winutilConfigTextBox.TabIndex = 12;
+            winutilConfigTextBox.TextChanged += winutilConfigTextBox_TextChanged;
+            // 
+            // winutilConfigBrowseBtn
+            // 
+            winutilConfigBrowseBtn.FlatStyle = FlatStyle.System;
+            winutilConfigBrowseBtn.Location = new Point(382, 285);
+            winutilConfigBrowseBtn.Name = "winutilConfigBrowseBtn";
+            winutilConfigBrowseBtn.Size = new Size(80, 23);
+            winutilConfigBrowseBtn.TabIndex = 13;
+            winutilConfigBrowseBtn.Text = "Browse...";
+            winutilConfigBrowseBtn.UseVisualStyleBackColor = true;
+            winutilConfigBrowseBtn.Click += winutilConfigBrowseBtn_Click;
+            // 
+            // winutilConfigDialog
+            // 
+            winutilConfigDialog.Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*";
             // 
             // label13
             // 
@@ -1117,6 +1156,10 @@
         internal System.Windows.Forms.Label label12;
         private System.Windows.Forms.CheckBox ReportToolCB;
         private System.Windows.Forms.ComboBox DriverExportCombo;
+        private System.Windows.Forms.Label winutilConfigLabel;
+        private System.Windows.Forms.TextBox winutilConfigTextBox;
+        private System.Windows.Forms.Button winutilConfigBrowseBtn;
+        private System.Windows.Forms.OpenFileDialog winutilConfigDialog;
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.CheckBox UnattendCopyCB;
         private System.Windows.Forms.Panel IsoCreationPage;

--- a/MicroWin/MainForm.cs
+++ b/MicroWin/MainForm.cs
@@ -449,6 +449,18 @@ namespace MicroWin
             AppState.UseUEFICA23Bins = UEFICA23CB.Checked;
         }
 
+        private void winutilConfigTextBox_TextChanged(object sender, EventArgs e)
+        {
+            AppState.WinUtilConfigPath = winutilConfigTextBox.Text;
+        }
+
+        private void winutilConfigBrowseBtn_Click(object sender, EventArgs e)
+        {
+            if (winutilConfigDialog.ShowDialog() == DialogResult.OK)
+            {
+                winutilConfigTextBox.Text = winutilConfigDialog.FileName;
+            }
+        }
 
         private void UpdateCurrentStatus(string text, bool resetBar = true)
         {
@@ -662,7 +674,21 @@ namespace MicroWin
                     try
                     {
                         var data = client.GetByteArrayAsync("https://github.com/CodingWonders/MicroWin/raw/main/MicroWin/tools/FirstStartup.ps1").GetAwaiter().GetResult();
-                        File.WriteAllBytes(Path.Combine(AppState.ScratchPath, "Windows", "FirstStartup.ps1"), data);
+                        string firstStartupPath = Path.Combine(AppState.ScratchPath, "Windows", "FirstStartup.ps1");
+                        File.WriteAllBytes(firstStartupPath, data);
+
+                        if (!string.IsNullOrWhiteSpace(AppState.WinUtilConfigPath) && File.Exists(AppState.WinUtilConfigPath))
+                        {
+                            File.Copy(AppState.WinUtilConfigPath, Path.Combine(AppState.ScratchPath, "winutil-config.json"), true);
+                            WriteLogMessage("WinUtil configuration file copied to image.");
+
+                            string scriptToAppend = "\n\nif (Test-Path -Path \"$env:HOMEDRIVE\\winutil-config.json\")\n" +
+                                                    "{\n" +
+                                                    "    Write-Host \"Configuration file detected. Applying...\"\n" +
+                                                    "    iex \"& { $(irm christitus.com/win) } -Config `\"$env:HOMEDRIVE\\winutil-config.json`\"\"\n" +
+                                                    "}\n";
+                            File.AppendAllText(firstStartupPath, scriptToAppend);
+                        }
                     }
                     catch { }
                 }


### PR DESCRIPTION
## Type of Change

* [x] **New feature**
* [ ] Bug fix
* [ ] Documentation update
* [ ] UI/UX improvement

## Description

In an effort to keep feature parity with the now-removed version integrated into `winutil` (which I personally loved for the config usage), this change allows a custom (and optional) config JSON exported from `winutil` to be used during the first sign-in automatically.

**Tested on Hyper-V VM:**

* `en-us_windows_11_iot_enterprise_ltsc_2024_x64_dvd_f6b14814` — *tested both with and without a winutil config.*

**References:**

* [winutil / Microwin-NewFirstRun.ps1 (L144-L148)](https://github.com/ChrisTitusTech/winutil/blob/ac116d70839be8a9312dbe9202999d2191bee67e/functions/microwin/Microwin-NewFirstRun.ps1#L144-L148)
* [winutil Automation Guide](https://github.com/ChrisTitusTech/winutil/blob/main/docs/src/content/docs/guides/automation.mdx)

