### PR TITLE
[DISMAPI] Divide cleanup progress by 10

### DIFF
--- a/MicroWin/functions/dism/DismManager.cs
+++ b/MicroWin/functions/dism/DismManager.cs
@@ -320,7 +320,7 @@ namespace MicroWin.functions.dism
                 using DismSession session = DismApi.OpenOfflineSession(mountPath.TrimEnd('\\'));
 
                 DismProgressCallback progressCallback = (currentProgress) => {
-                    progress(currentProgress.Current);
+                    progress(currentProgress.Current / 10);
                 };
 
                 DismApi.CleanImage(session, DismCleanImageType.Component, DismCleanImageFlags.ResetBase, progressCallback);


### PR DESCRIPTION
Divide cleanup progress by 10

The CleanImage function returns progress in a range of 0-1000. That last digit is meant to be the decimal number in DISM